### PR TITLE
Fix alignment check when there is no alignment

### DIFF
--- a/direct_io.go
+++ b/direct_io.go
@@ -31,6 +31,9 @@ func alignment(block []byte, AlignSize int) int {
 
 // IsAligned checks wether passed byte slice is aligned
 func IsAligned(block []byte) bool {
+	if AlignSize == 0 {
+		return true
+	}
 	return alignment(block, AlignSize) == 0
 }
 


### PR DESCRIPTION
In Darwin `AlignSize = 0`, which results in `IsAligned()` to always return false. When no alignment is necessary, data is always aligned.